### PR TITLE
Fix/linkify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 # CHANGELOG
 
 ## Unreleased
+
+- Linkify after markdown generated html. [#3](https://github.com/jollygoodcode/html-pipeline-linkify_github/pull/3/)
+
+## 2015.10.04
+
+Released v1.0.0.

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :development do
   gem "rake"
   gem "bundler"
   gem "pry"
+  gem "github-markdown"
 end
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -21,32 +21,32 @@ Or install it yourself as:
 
 ## Usage
 
-**Use `HTML::Pipeline::LinkifyGitHubFilter` filter before your markdown filter.**
+**Use `HTML::Pipeline::LinkifyGitHubFilter` filter after your markdown filter.**
 
 ```ruby
 require "html/pipeline"
 require "html/pipeline/linkify_github"
 
 pipeline = HTML::Pipeline.new [
-  HTML::Pipeline::LinkifyGitHubFilter,
-  HTML::Pipeline::MarkdownFilter
+  HTML::Pipeline::MarkdownFilter,
+  HTML::Pipeline::LinkifyGitHubFilter
 ]
 
-result = pipeline.call <<-CODE
+result = pipeline.call <<-MARKDOWN.strip_heredoc
   https://github.com/rails/rails/pull/21862
   https://github.com/rails/rails/issues/21843
   https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864
-CODE
+MARKDOWN
 
-puts result[:output]
+puts result[:output].to_html
 ```
 
 prints:
 
-```markdown
-  [rails/rails#21862](https://github.com/rails/rails/pull/21862)
-  [rails/rails#21843](https://github.com/rails/rails/issues/21843)
-  [rails/rails@`67597e1`](https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864)
+```html
+<p><a href="https://github.com/rails/rails/pull/21862">rails/rails#21862</a><br>
+<a href="https://github.com/rails/rails/issues/21843">rails/rails#21843</a><br>
+<a href="https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864">rails/rails@`67597e`</a></p>
 ```
 
 ## Notes

--- a/test/linkify_github_integration_test.rb
+++ b/test/linkify_github_integration_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "html/pipeline"
+require "html/pipeline/linkify_github"
+require "github/markdown"
+
+class HTML::Pipeline::LinkifyGitHubIntegrationTest < Minitest::Test
+  def pipeline
+    @pipeline ||= HTML::Pipeline.new [
+      HTML::Pipeline::MarkdownFilter,
+      HTML::Pipeline::LinkifyGitHubFilter
+    ]
+  end
+  def test_works_with_markdown_filter
+    result = pipeline.call <<-MARKDOWN.strip_heredoc
+      https://github.com/rails/rails/pull/21862
+      https://github.com/rails/rails/issues/21843
+      https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864
+    MARKDOWN
+
+    assert_equal "<p><a href=\"https://github.com/rails/rails/pull/21862\">rails/rails#21862</a><br>\n<a href=\"https://github.com/rails/rails/issues/21843\">rails/rails#21843</a><br>\n<a href=\"https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864\">rails/rails@`67597e`</a></p>",
+                 result[:output].to_html
+  end
+
+  def test_works_when_markdown_already_linkified
+    result = pipeline.call <<-MARKDOWN.strip_heredoc
+      - [rails/rails#21862](https://github.com/rails/rails/pull/21862)
+    MARKDOWN
+
+    assert_equal "<ul>\n<li><a href=\"https://github.com/rails/rails/pull/21862\">rails/rails#21862</a></li>\n</ul>",
+                 result[:output].to_html
+  end
+end

--- a/test/linkify_github_test.rb
+++ b/test/linkify_github_test.rb
@@ -3,131 +3,50 @@ require "test_helper"
 class HTML::Pipeline::LinkifyGitHubTest < Minitest::Test
   LinkifyGitHubFilter = HTML::Pipeline::LinkifyGitHubFilter
 
-  def filter(text)
-    LinkifyGitHubFilter.to_html(text)
+  def filter(html)
+    LinkifyGitHubFilter.call(html)
   end
 
   def test_that_it_has_a_version_number
     assert HTML::Pipeline::LinkifyGitHub::VERSION
   end
 
-  def test_that_normal_url_will_not_linkify
-    text = "https://www.deppbot.com"
-
-    assert_equal text, filter(text)
+  def pull_request_url
+    "https://github.com/rails/rails/pull/21862"
   end
 
-  # == Pull Request
-
-  def test_that_linkify_pull_request_url
-    text = "https://github.com/rails/rails/pull/21862"
-
-    assert_equal "[rails/rails#21862](https://github.com/rails/rails/pull/21862)", filter(text)
+  def issue_url
+    "https://github.com/rails/rails/issues/21843"
   end
 
-  def test_that_linkify_pull_request_url_with_end_tilde
-    text = "https://github.com/rails/rails/pull/21862/"
-
-    assert_equal "[rails/rails#21862](https://github.com/rails/rails/pull/21862)", filter(text)
+  def commit_url
+    "https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864"
   end
 
-  def test_that_linkify_pull_request_url_with_www
-    text = "https://www.github.com/rails/rails/pull/21862"
+  def test_linkify_github_pull_request_html_link
+    body = %Q(<a href="#{pull_request_url}">#{pull_request_url}</a>)
+    doc  = Nokogiri::HTML::DocumentFragment.parse(body)
 
-    assert_equal "[rails/rails#21862](https://github.com/rails/rails/pull/21862)", filter(text)
+    res = filter(doc)
+    assert_equal_html %Q(<a href="#{pull_request_url}">rails/rails#21862</a>),
+                      res.to_html
   end
 
-  def test_that_linkify_pull_request_url_http
-    text = "http://github.com/rails/rails/pull/21862"
+  def test_linkify_github_issue_html_link
+    body = %Q(<a href="#{issue_url}">#{issue_url}</a>)
+    doc  = Nokogiri::HTML::DocumentFragment.parse(body)
 
-    assert_equal "[rails/rails#21862](https://github.com/rails/rails/pull/21862)", filter(text)
+    res = filter(doc)
+    assert_equal_html %Q(<a href="#{issue_url}">rails/rails#21843</a>),
+                      res.to_html
   end
 
-  def test_that_linkify_pull_request_url_http_www
-    text = "http://www.github.com/rails/rails/pull/21862"
+  def test_linkify_github_commit_html_link
+    body = %Q(<a href="#{commit_url}">#{commit_url}</a>)
+    doc  = Nokogiri::HTML::DocumentFragment.parse(body)
 
-    assert_equal "[rails/rails#21862](https://github.com/rails/rails/pull/21862)", filter(text)
-  end
-
-  def test_that_linkify_with_invalid_pull_request_url
-    text = "https://github.com/rails/rails/pull/"
-
-    assert_equal text, filter(text)
-  end
-
-  # == Issue
-
-  def test_that_linkify_issue_url
-    text = "https://github.com/rails/rails/issues/21862"
-
-    assert_equal "[rails/rails#21862](https://github.com/rails/rails/issues/21862)", filter(text)
-  end
-
-  def test_that_linkify_issue_url_with_end_tilde
-    text = "https://github.com/rails/rails/issues/21862/"
-
-    assert_equal "[rails/rails#21862](https://github.com/rails/rails/issues/21862)", filter(text)
-  end
-
-  def test_that_linkify_issue_url_with_www
-    text = "https://www.github.com/rails/rails/issues/21862"
-
-    assert_equal "[rails/rails#21862](https://github.com/rails/rails/issues/21862)", filter(text)
-  end
-
-  def test_that_linkify_issue_url_http
-    text = "http://github.com/rails/rails/issues/21862"
-
-    assert_equal "[rails/rails#21862](https://github.com/rails/rails/issues/21862)", filter(text)
-  end
-
-  def test_that_linkify_issue_url_http_www
-    text = "http://www.github.com/rails/rails/issues/21862"
-
-    assert_equal "[rails/rails#21862](https://github.com/rails/rails/issues/21862)", filter(text)
-  end
-
-  def test_that_linkify_with_invalid_issue_url
-    text = "https://github.com/rails/rails/issues/"
-
-    assert_equal text, filter(text)
-  end
-
-    # == Commit
-
-  def test_that_linkify_commit_url
-    text = "https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864"
-
-    assert_equal "[rails/rails@`67597e1`](https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864)", filter(text)
-  end
-
-  def test_that_linkify_commit_url_with_end_tilde
-    text = "https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864/"
-
-    assert_equal "[rails/rails@`67597e1`](https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864)", filter(text)
-  end
-
-  def test_that_linkify_commit_url_with_www
-    text = "https://www.github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864"
-
-    assert_equal "[rails/rails@`67597e1`](https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864)", filter(text)
-  end
-
-  def test_that_linkify_commit_url_with_http
-    text = "http://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864"
-
-    assert_equal "[rails/rails@`67597e1`](https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864)", filter(text)
-  end
-
-  def test_that_linkify_commit_url_with_http_www
-    text = "http://www.github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864"
-
-    assert_equal "[rails/rails@`67597e1`](https://github.com/rails/rails/commit/67597e1719ec6af7e22964603cc77aa5b085a864)", filter(text)
-  end
-
-  def test_that_linkify_with_invalid_commit_url
-    text = "http://www.github.com/rails/rails/commit/"
-
-    assert_equal text, filter(text)
+    res = filter(doc)
+    assert_equal_html %Q(<a href="#{commit_url}">rails/rails@`67597e`</a>),
+                      res.to_html
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,20 @@
 require "bundler/setup"
 require "minitest/autorun"
 require "html/pipeline/linkify_github"
+
+module LinkifyGitHubTestExtensions
+  def assert_equal_html(expected, actual)
+    assert_equal Nokogiri::HTML::DocumentFragment.parse(expected).to_hash,
+                 Nokogiri::HTML::DocumentFragment.parse(actual).to_hash
+  end
+end
+
+class Minitest::Test
+  include LinkifyGitHubTestExtensions
+end
+
+class String
+  def strip_heredoc
+    gsub(/^#{scan(/^[ \t]*(?=\S)/).min}/, "".freeze)
+  end
+end


### PR DESCRIPTION
Fixes #2.

Looking for markdown pattern for links is a rabbit hole. Instead of being a plain text filter, change to a [filter](https://github.com/jch/html-pipeline/blob/f6c5988e5c67cade88a1d543dc33a4e6d218f56a/lib/html/pipeline/filter.rb) and do the linkify after markdown filter has generated its html.
