### PR TITLE
issue-6: update dependencies for ruby 3.x+; remove outdated ruby versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@
 /spec/reports/
 /tmp/
 *.bundle
+*.gem
 *.so
 *.o
 *.a
+*.ruby-version
 mkmf.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ cache: bundler
 language: ruby
 sudo: false
 rvm:
-  - 2.0.0
-  - 2.1.7
-  - 2.2.3
+  - 2.7
+  - 3.0
+  - 3.1
+  - 3.2
   - ruby-head
 matrix:
   allow_failures:

--- a/html-pipeline-linkify_github.gemspec
+++ b/html-pipeline-linkify_github.gemspec
@@ -13,10 +13,14 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/juanitofatas/html-pipeline-linkify_github"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f=~ %r{^(test)/ }
+  end
+
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "html-pipeline", ">= 1.11"
+  spec.add_dependency "html-pipeline", ">= 2.10"
+  spec.add_dependency "commonmarker", ">= 0.20"
 
-  spec.required_ruby_version = "~> 2.0"
+  spec.required_ruby_version = ">= 2.7"
 end

--- a/lib/html/pipeline/linkify_github/version.rb
+++ b/lib/html/pipeline/linkify_github/version.rb
@@ -1,7 +1,7 @@
 module HTML
   class Pipeline
     module LinkifyGitHub
-      VERSION = "1.0.2".freeze
+      VERSION = '1.0.3'.freeze
     end
   end
 end


### PR DESCRIPTION
resolves #6 

- Updates for current ruby versions (2.7, 3.0, 3.1, 3.2)
- Adds required dependency on commonmarker
- provides future support for commonmarker 1+ and html-pipeline 3+